### PR TITLE
fix "if grad:" issue

### DIFF
--- a/tf_rl/controller/discrete_deepq.py
+++ b/tf_rl/controller/discrete_deepq.py
@@ -146,7 +146,7 @@ class DiscreteDeepQ(object):
             # Add histograms for gradients.
             for grad, var in gradients:
                 tf.histogram_summary(var.name, var)
-                if grad:
+                if grad is not None:
                     tf.histogram_summary(var.name + '/gradients', grad)
             self.train_op                   = self.optimizer.apply_gradients(gradients)
 


### PR DESCRIPTION
TF warning:

> TypeError: Using a `tf.Tensor` as a Python `bool` is not allowed. Use `if t is not None:` instead of `if t:` to test if a tensor is defined, and use the logical TensorFlow ops to test the value of a tensor.

Seems like it should be "if grad is not None", not just "if grad"
