### PR TITLE
Fix integer division

### DIFF
--- a/tf_rl/simulate.py
+++ b/tf_rl/simulate.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import math
 import time
 


### PR DESCRIPTION
Both `frame_no` and `fps` are integers in `time_should_have_passed = frame_no / fps`, so `time_should_have_passed` is only updated periodically when `frame_no` is incremented. 
