### PR TITLE
Change import svg to relative importing

### DIFF
--- a/tf_rl/simulation/double_pendulum.py
+++ b/tf_rl/simulation/double_pendulum.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-import tf_rl.utils.svg as svg
+from ..utils import svg
 
 class DoublePendulum(object):
     def __init__(self, params):

--- a/tf_rl/simulation/karpathy_game.py
+++ b/tf_rl/simulation/karpathy_game.py
@@ -7,7 +7,7 @@ import time
 from collections import defaultdict
 from euclid import Circle, Point2, Vector2, LineSegment2
 
-import tf_rl.utils.svg as svg
+from ..utils import svg
 
 class GameObject(object):
     def __init__(self, position, speed, obj_type, settings):


### PR DESCRIPTION
When import tf_rl.utils.svg as svg, it assumes we are working from the
project root. 

It causes troubles when tf_rl is used as a library.
