### PR TITLE
Add environment draw option with setup_draw() and draw()

### DIFF
--- a/tf_rl/simulate.py
+++ b/tf_rl/simulate.py
@@ -3,7 +3,7 @@ from __future__ import division
 import math
 import time
 
-from IPython.display import clear_output, display, HTML
+import matplotlib.pyplot as plt
 from itertools import count
 from os.path import join, exists
 from os import makedirs
@@ -71,6 +71,10 @@ def simulate(simulation,
 
     simulation_started_time = time.time()
 
+    # setup rendering handles for reuse
+    if hasattr(simulation, 'setup_draw'): 
+        simulation.setup_draw()
+
     for frame_no in count():
         for _ in range(chunks_per_frame):
             simulation.step(chunk_length_s)
@@ -98,9 +102,11 @@ def simulate(simulation,
         # action taking.
         if (frame_no + 1) % visualize_every == 0:
             fps_estimate = frame_no / (time.time() - simulation_started_time)
-            clear_output(wait=True)
-            svg_html = simulation.to_html(["fps = %.1f" % (fps_estimate,)])
-            display(svg_html)
+
+            # draw simulated environment all the rendering is handled within the simulation object 
+            if hasattr(simulation, 'draw'): #
+                simulation.draw(["fps = %.1f" % (fps_estimate, )]) 
+
             if save_path is not None:
                 img_path = join(save_path, "%d.svg" % (last_image,))
                 with open(img_path, "w") as f:

--- a/tf_rl/simulation/karpathy_game.py
+++ b/tf_rl/simulation/karpathy_game.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from euclid import Circle, Point2, Vector2, LineSegment2
 
 from ..utils import svg
+from IPython.display import clear_output, display, HTML
 
 class GameObject(object):
     def __init__(self, position, speed, obj_type, settings):
@@ -296,3 +297,10 @@ class KarpathyGame(object):
 
         return scene
 
+    def setup_draw(self):
+        pass
+
+    def draw(self, stats):
+        clear_output(wait=True)
+        svg_html = self.to_html(stats)
+        display(svg_html)

--- a/tf_rl/simulation/karpathy_game.py
+++ b/tf_rl/simulation/karpathy_game.py
@@ -298,9 +298,20 @@ class KarpathyGame(object):
         return scene
 
     def setup_draw(self):
+        """
+        An optional method to be triggered in simulate(...) to initialise
+        the figure handles for rendering.
+        simulate(...) will run with/without this method declared in the simulation class
+        As we are using SVG strings in KarpathyGame, it is not curently used.
+        """
         pass
 
     def draw(self, stats=[]):
+        """
+        An optional method to be triggered in simulate(...) to render the simulated environment.
+        It is repeatedly called in each simulated iteration.
+        simulate(...) will run with/without this method declared in the simulation class.
+        """
         clear_output(wait=True)
         svg_html = self.to_html(stats)
         display(svg_html)

--- a/tf_rl/simulation/karpathy_game.py
+++ b/tf_rl/simulation/karpathy_game.py
@@ -300,7 +300,7 @@ class KarpathyGame(object):
     def setup_draw(self):
         pass
 
-    def draw(self, stats):
+    def draw(self, stats=[]):
         clear_output(wait=True)
         svg_html = self.to_html(stats)
         display(svg_html)


### PR DESCRIPTION
simulate(...) no longer assumes the environment can only be drawn with svg
strings. Instead it calls a `simulation.setup_draw()` before the loop to
setup the figure handles & calls `simulation.draw()` within the loop.
These two methods are optional for the environment class (only called if the class has such two methods).

To adapt this change, I also added `setup_draw()` and `draw()` in karpathy_game

Historical code with `to_html()` are supported as well just in case.
